### PR TITLE
Port synthesis tests to VHDL

### DIFF
--- a/src/peakrdl_regblock_vhdl/cpuif/avalon/__init__.py
+++ b/src/peakrdl_regblock_vhdl/cpuif/avalon/__init__.py
@@ -42,6 +42,10 @@ class Avalon_Cpuif_flattened(Avalon_Cpuif):
     is_interface = False
 
     @property
+    def package_name(self) -> Union[str, None]:
+        return None
+
+    @property
     def port_declaration(self) -> str:
         lines = [
             self.signal("read")               +  " : in std_logic;",

--- a/tests/lib/synth_testcase.py
+++ b/tests/lib/synth_testcase.py
@@ -10,9 +10,10 @@ class SynthTestCase(BaseTestCase):
 
     def _get_synth_files(self) -> List[str]:
         files = []
-        files.extend(self.cpuif.get_synth_files())
-        files.append("regblock_pkg.sv")
-        files.append("regblock.sv")
+        files.extend(file for file in self.cpuif.get_synth_files() if file.endswith(".vhd"))
+        files.append("vhdl_regblock_pkg.vhd")
+        files.append("vhdl_regblock.vhd")
+        files.append("../../../../hdl-src/reg_utils.vhd")
 
         return files
 

--- a/tests/lib/synthesizers/vivado_scripts/run.tcl
+++ b/tests/lib/synthesizers/vivado_scripts/run.tcl
@@ -23,9 +23,9 @@ set_msg_config -severity {CRITICAL WARNING} -new_severity "ERROR"
 
 
 set_part [lindex [get_parts] 0]
-read_verilog -sv $files
+read_vhdl -vhdl2008 $files
 read_xdc $this_dir/constr.xdc
-synth_design -top regblock -mode out_of_context
+synth_design -top vhdl_regblock -mode out_of_context
 
 #write_checkpoint -force synth.dcp
 


### PR DESCRIPTION
Synthesis tests now build the VHDL regblock. All pass.

The `use` clause for the `avalon_mm_intf_pkg` was removed when using the flattened Intel avalon interface.
